### PR TITLE
Docstring corrections and suggestion

### DIFF
--- a/src/cross_section.jl
+++ b/src/cross_section.jl
@@ -21,7 +21,7 @@ scattering angle (`cos_theta`), i.e. the angle between the incoming electron and
 This function computes the differential cross section using the following formula (from Schwartz 2014):
 
 ```math
-\\frac{\\mathrm{d}\\sigma}{\\mathrm{d}\\Omega} = \\frac{\\alpha^2}{16 E_{\\mathrm{in}}^6}\\left( E_{\\text{in}}^4 + \\rho_e^2 \\rho_\\mu^2 \\cos^2\\theta + E_{\\text{in}}^2 \\left( m_e^2 + m_\\mu^2 \\right) \\right)
+\\frac{\\mathrm{d}\\sigma}{\\mathrm{d}\\Omega} = \\frac{\\rho_\\mu}{\\rho_e} \\cdot \\frac{\\alpha^2}{16 E_{\\mathrm{in}}^6}\\left( E_{\\text{in}}^4 + \\rho_e^2 \\rho_\\mu^2 \\cos^2\\theta + E_{\\text{in}}^2 \\left( m_e^2 + m_\\mu^2 \\right) \\right)
 ```
 
 where:
@@ -89,6 +89,3 @@ function total_cross_section(E_in)
     # FIXME: fill me in
     #
 end
-
-
-

--- a/src/four_momentum.jl
+++ b/src/four_momentum.jl
@@ -132,7 +132,7 @@ Computes the Minkowski dot product of two four-momentum vectors. The dot product
 Minkowski metric `(+,-,-,-)`. For ``p_i = (E_i,p_i^x,p_i^y,p_i^z)`` with ``i=1,2``, the result is:
 
 ```math
-    p_1 \\cdot p_2 = E_1E_2 - p_1^xp_2^x - p_1^yp_2^y + p_1^zp_2^z
+    p_1 \\cdot p_2 = E_1E_2 - p_1^xp_2^x - p_1^yp_2^y - p_1^zp_2^z
 ```
 
 # Example
@@ -166,6 +166,10 @@ end
 Constructs the four-momenta for an electron-positron annihilation process ``e^+ e^- \\rightarrow \\mu^+ \\mu^-``
 in the center-of-mass frame. The input energy (`E_in`), scattering angle (`cos_theta`), and azimuthal angle (`phi`) 
 are used to compute the incoming and outgoing momenta for the particles.
+
+Assumes the ``e^+ e^-`` collision is colinear with the `z`-axis, and then rotates the ``\\mu^+\\mu^-`` components relative to them.
+The 3-momentum magnitude is given by `rho`, for a given particle mass and energy.
+The components in the ``x,y,z`` axes will be ``sin(theta) * cos(phi)``, ``sin(theta) * sin(phi)``, ``cos_theta`` respectively.
 
 # Returns
 A `Dict` mapping the particle names ("e-", "e+", "mu-", "mu+") to their respective `FourMomentum` objects.


### PR DESCRIPTION
- Correction in `differential_cross_section` docstring, adding term $`\frac{\rho_\mu}{\rho_e}`$
- Correction in `minkowski_dot` docstring, + signal replaced with -
- Suggestion based on notebook1 content, adding more context in `coords_to_dict` docstring. As a non-physicist, it was already somewhat difficult to get there with the added context 😁

Great work on the material!! 👍 